### PR TITLE
PB-62 fix: update OrderView to handle invalid addresses

### DIFF
--- a/src/main/java/co/edu/uptc/views/OrderView.java
+++ b/src/main/java/co/edu/uptc/views/OrderView.java
@@ -158,7 +158,7 @@ public class OrderView extends HttpServlet implements SupportsPatch {
         Node finish = orderController.findNode(geocoding(destinationAddress));
         orderController.editPathOrder(start, finish, order);
 
-      } catch (ApiException | InterruptedException | IOException e) {
+      } catch (Exception e) {
         req.setAttribute("errorMessageGoogleMaps", "Dirrección no es válida");
         ServletUtils.forward(req, resp, "/pages/addorder.jsp");
         return;


### PR DESCRIPTION
The code changes in `OrderView.java` handle exceptions when geocoding the destination address. Instead of catching specific exceptions, a generic `Exception` catch block is used to handle any type of exception that may occur during the geocoding process. If an exception is caught, an error message is set in the request attribute and the user is redirected to the add order page. This ensures that invalid addresses are properly handled and the user is notified of the error.