### PR TITLE
PB-64 fix: recalculate the route when edit order

### DIFF
--- a/src/main/java/co/edu/uptc/views/OrderView.java
+++ b/src/main/java/co/edu/uptc/views/OrderView.java
@@ -284,6 +284,17 @@ public class OrderView extends HttpServlet implements SupportsPatch {
     order.setStatus(Status.fromString(state));
     order.setResponsible(responsible);
     orderController.edit(order);
+    if (order != null) {
+      try {
+        Node start = orderController.findNode(this.geocoding(order.getSourceAddress()));
+        Node finish = orderController.findNode(this.geocoding(order.getDestinationAddress()));
+        orderController.editPathOrder(start, finish, order);
+      } catch (Exception e) {
+        req.setAttribute("errorMessageGoogleMaps", "Dirrección no es válida");
+        ServletUtils.forward(req, resp, "/pages/editorder.jsp");
+        return;
+      }
+    }
     resp.sendRedirect("/project-programation/orders");
   }
 

--- a/src/main/webapp/pages/editorder.jsp
+++ b/src/main/webapp/pages/editorder.jsp
@@ -216,6 +216,12 @@
                   </div>
                 </c:if>
             </div>
+            <c:if test="${not empty errorMessageGoogleMaps}">
+              <div class="lg:col-span-2 lg:py-12 lg:text-center lg:pl-8 flex items-center justify-center"
+                style="color: red;">
+                ${errorMessageGoogleMaps}
+              </div>
+            </c:if>
             <div id="addressModal" class="${not empty errorMessageAddress ? '' : 'hidden'} fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center">
                 <div class="bg-white rounded-lg shadow-lg p-6 w-full max-w-4xl">
                   <h2 class="text-2xl text-black mb-4">Dirección de Destino</h2>


### PR DESCRIPTION
"This pull request fixes PB-64 by adding an error message for Google Maps in the editorder.jsp file. If there is an error with the Google Maps API, the error message will be displayed in red on the page. This improves the user experience by providing feedback when there is an issue with the Google Maps functionality. Additionally, the pull request includes changes to recalculate with the new direction if the order is not null. If there is an exception while calculating the path order, an error message 'Dirección no es válida' will be displayed in red on the page. The changes in the editorder.jsp file and the associated patches ensure that the error messages are properly displayed and enhance the overall functionality of the application."